### PR TITLE
Abstract Class names in Applications

### DIFF
--- a/src/main/resources/checkstyle-application.xml
+++ b/src/main/resources/checkstyle-application.xml
@@ -145,7 +145,7 @@ THE SOFTWARE.
          https://checkstyle.sourceforge.io/config_modifier.html
       -->
       <module name="AbstractClassName"> 
-         <property name="format" value="^A[A-Z]*.+$"/>
+         <property name="format" value="^A[A-Z].+$"/>
       </module>
       <module name="ClassTypeParameterName"/>
       <module name="ConstantName"/>


### PR DESCRIPTION
Fix name of Abstract classes in checkstyle-application.xml config.